### PR TITLE
add support for archiving snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ build-backend:
 build-backend-docker:
 	@cd ./backend && docker build .
 
-ci: init up test lint-backend build-backend build-frontend
+ci: init up lint-backend test build-backend build-frontend
 
 deploy: deploy-frontend deploy-backend browse
 	

--- a/backend/__tests__/domain/inventory/archiveSnapshotInMemory.unit.test.ts
+++ b/backend/__tests__/domain/inventory/archiveSnapshotInMemory.unit.test.ts
@@ -1,3 +1,0 @@
-describe("ArchiveSnapshotInMemory", () => {
-  it(`should throw if the snapshot can't be found`, async () => {});
-});

--- a/backend/__tests__/domain/inventory/archiveSnapshotInMemory.unit.test.ts
+++ b/backend/__tests__/domain/inventory/archiveSnapshotInMemory.unit.test.ts
@@ -1,0 +1,3 @@
+describe("ArchiveSnapshotInMemory", () => {
+  it(`should throw if the snapshot can't be found`, async () => {});
+});

--- a/backend/__tests__/domain/inventory/downSyncInventory.unit.test.ts
+++ b/backend/__tests__/domain/inventory/downSyncInventory.unit.test.ts
@@ -4,6 +4,7 @@ import {
   StoreSnapshotInMemory,
   TakeSnapshotsForAllShops,
 } from "../../../src/domain/inventory";
+import { Snapshot } from "../../../src/domain/inventory/models/snapshots/snapshot";
 import { Shop, GetAllShopsFromMemory } from "../../../src/domain/shops";
 import { singleCabinetItem } from "../../fixtures";
 
@@ -30,12 +31,12 @@ describe("DownSyncInventory", () => {
   externalShopInventories.set(firstShop.id, [firstShopInventory]);
   externalShopInventories.set(secondShop.id, [secondShopInventory]);
 
-  const synchronizedInventories = new Map<string, CabinetItem[]>();
+  const storedSnapshots = new Map<string, Snapshot[]>();
   const getAllShops = new GetAllShopsFromMemory(shops);
   const fetchInventory = new FetchMockedSnapshotFromMemory(
     externalShopInventories
   );
-  const storeInventory = new StoreSnapshotInMemory(synchronizedInventories);
+  const storeInventory = new StoreSnapshotInMemory(storedSnapshots);
   it("should retrieve and store all shops' inventory", async () => {
     const downSyncInventory = new TakeSnapshotsForAllShops(
       getAllShops,
@@ -45,12 +46,12 @@ describe("DownSyncInventory", () => {
 
     await downSyncInventory.run();
 
-    expect(synchronizedInventories.size).toBe(2);
-    expect(synchronizedInventories.get(firstShop.id)).toEqual([
-      firstShopInventory,
-    ]);
-    expect(synchronizedInventories.get(secondShop.id)).toEqual([
-      secondShopInventory,
-    ]);
+    expect(storedSnapshots.size).toBe(2);
+    expect(
+      storedSnapshots.get(firstShop.id)?.flatMap((s) => s.contents)
+    ).toEqual([firstShopInventory]);
+    expect(
+      storedSnapshots.get(secondShop.id)?.flatMap((s) => s.contents)
+    ).toEqual([secondShopInventory]);
   });
 });

--- a/backend/__tests__/ports/postgres/inventory/archiveSnapshotInPostgres.int.test.ts
+++ b/backend/__tests__/ports/postgres/inventory/archiveSnapshotInPostgres.int.test.ts
@@ -1,8 +1,5 @@
-import { assert } from "console";
 import { randomUUID } from "crypto";
 import { SnapshotNotFoundError } from "../../../../src/domain/inventory/models/errors/snapshotNotFoundError";
-import { Snapshot } from "../../../../src/domain/inventory/models/snapshots/snapshot";
-import { Shop } from "../../../../src/domain/shops";
 import {
   GetSnapshotFromPostgres,
   StoreSnapshotInPostgres,

--- a/backend/__tests__/ports/postgres/inventory/archiveSnapshotInPostgres.int.test.ts
+++ b/backend/__tests__/ports/postgres/inventory/archiveSnapshotInPostgres.int.test.ts
@@ -1,0 +1,48 @@
+import { assert } from "console";
+import { randomUUID } from "crypto";
+import { SnapshotNotFoundError } from "../../../../src/domain/inventory/models/errors/snapshotNotFoundError";
+import { Snapshot } from "../../../../src/domain/inventory/models/snapshots/snapshot";
+import { Shop } from "../../../../src/domain/shops";
+import {
+  GetSnapshotFromPostgres,
+  StoreSnapshotInPostgres,
+} from "../../../../src/ports/postgres/inventory";
+import { ArchiveSnapshotInPostgres } from "../../../../src/ports/postgres/inventory/archiveSnapshotInPostgres";
+import { CreateNewShopInPostgres } from "../../../../src/ports/postgres/shops";
+import { getTestDatabase } from "../../../lifecycle/getTestDatabase";
+
+describe("ArchiveSnapshotInPostgres", () => {
+  const createSutAndFixtures = () => {
+    const { database } = getTestDatabase();
+    return {
+      fixtures: {
+        storeSnapshot: new StoreSnapshotInPostgres(database),
+        createShop: new CreateNewShopInPostgres(database),
+        getSnapshot: new GetSnapshotFromPostgres(database),
+      },
+      archiveSnapshot: new ArchiveSnapshotInPostgres(database),
+    };
+  };
+  it("should throw if a snapshot could not be found to archive", async () => {
+    const { archiveSnapshot } = createSutAndFixtures();
+    const id = randomUUID();
+    await expect(async () => archiveSnapshot.execute(id)).rejects.toThrow(
+      SnapshotNotFoundError
+    );
+  });
+  it("should mark a snapshot that is not archived yet as archived", async () => {
+    expect.hasAssertions();
+
+    const {
+      archiveSnapshot,
+      fixtures: { storeSnapshot, createShop, getSnapshot },
+    } = createSutAndFixtures();
+    const createdShop = await createShop.execute({ name: "test shop" });
+    const existingSnapshot = await storeSnapshot.forShop(createdShop.id, []);
+    expect(existingSnapshot.archived).toBeFalsy();
+
+    await archiveSnapshot.execute(existingSnapshot.id);
+    const archivedSnapshot = await getSnapshot.byId(existingSnapshot.id);
+    expect(archivedSnapshot.archived).toBeTruthy();
+  });
+});

--- a/backend/__tests__/ports/postgres/inventory/storeSnapshotInPostgres.int.test.ts
+++ b/backend/__tests__/ports/postgres/inventory/storeSnapshotInPostgres.int.test.ts
@@ -1,3 +1,4 @@
+import { assert } from "console";
 import { randomUUID } from "crypto";
 import { CabinetItem } from "../../../../src/domain/inventory";
 import {
@@ -45,5 +46,33 @@ describe("StoreSnapshot", () => {
       firstItem,
       secondItem,
     ]);
+  });
+  it("should return the created snapshot", async () => {
+    expect.hasAssertions();
+    const {
+      storeSnapshot,
+      fixtures: { createShop },
+    } = createSutAndFixtures();
+    const { id } = await createShop.execute({ name: "test shop" });
+    const created = await storeSnapshot.forShop(id, [singleCabinetItem]);
+    expect(created).toBeDefined();
+  });
+  it("should stamp a snapshot with a time of creation", async () => {
+    const {
+      storeSnapshot,
+      fixtures: { createShop },
+    } = createSutAndFixtures();
+    const { id } = await createShop.execute({ name: "test shop" });
+    const created = await storeSnapshot.forShop(id, [singleCabinetItem]);
+    expect(created.createdAt).toBeDefined();
+  });
+  it("should initially set it to unarchived", async () => {
+    const {
+      storeSnapshot,
+      fixtures: { createShop },
+    } = createSutAndFixtures();
+    const { id } = await createShop.execute({ name: "test shop" });
+    const created = await storeSnapshot.forShop(id, [singleCabinetItem]);
+    expect(created.archived).toBeFalse();
   });
 });

--- a/backend/__tests__/ports/postgres/inventory/storeSnapshotInPostgres.int.test.ts
+++ b/backend/__tests__/ports/postgres/inventory/storeSnapshotInPostgres.int.test.ts
@@ -1,4 +1,3 @@
-import { assert } from "console";
 import { randomUUID } from "crypto";
 import { CabinetItem } from "../../../../src/domain/inventory";
 import {

--- a/backend/migrations/1639491679246_add-archived-flag-to-raw-inventory-data.js
+++ b/backend/migrations/1639491679246_add-archived-flag-to-raw-inventory-data.js
@@ -1,0 +1,17 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = pgm => {
+  pgm.sql(`
+    ALTER TABLE raw_inventory_data
+      ADD COLUMN archived BOOLEAN NOT NULL DEFAULT FALSE
+    `)
+};
+
+exports.down = pgm => {
+  pgm.sql(`
+    ALTER TABLE raw_inventory_data
+      DROP COLUMN archived
+    `)
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,7 @@
     "int": "jest -c jest.config.int.js",
     "e2e": "jest -c jest.config.e2e.js --runInBand",
     "build": "tsc -p ./tsconfig.build.json",
-    "lint": "eslint . --ext .ts",
+    "lint": "eslint . --ext .ts --max-warnings=0",
     "fmt": "eslint . --ext .ts --fix",
     "migrate": "node-pg-migrate",
     "backfill": "ts-node ./tools/backfill-production-to-dev",

--- a/backend/src/domain/inventory/archiveSnapshot.ts
+++ b/backend/src/domain/inventory/archiveSnapshot.ts
@@ -2,21 +2,19 @@ import { SnapshotNotFoundError } from "./models/errors/snapshotNotFoundError";
 import { Snapshot, SnapshotId } from "./models/snapshots/snapshot";
 
 interface ArchiveSnapshot {
-  execute(id: SnapshotId): Promise<Snapshot>;
+  execute(id: SnapshotId): Promise<void>;
 }
 
 class ArchiveSnapshotInMemory implements ArchiveSnapshot {
   constructor(private readonly snapShots: Map<string, Snapshot>) {}
 
-  async execute(id: SnapshotId): Promise<Snapshot> {
+  async execute(id: SnapshotId): Promise<void> {
     const foundSnapshot = this.snapShots.get(id);
     if (!foundSnapshot) {
       throw new SnapshotNotFoundError(id);
     }
 
     this.snapShots.set(id, { ...foundSnapshot, archived: true });
-
-    return foundSnapshot;
   }
 }
 

--- a/backend/src/domain/inventory/archiveSnapshot.ts
+++ b/backend/src/domain/inventory/archiveSnapshot.ts
@@ -1,14 +1,14 @@
 import { SnapshotNotFoundError } from "./models/errors/snapshotNotFoundError";
-import { Snapshot } from "./models/snapshots/snapshot";
+import { Snapshot, SnapshotId } from "./models/snapshots/snapshot";
 
 interface ArchiveSnapshot {
-  execute(id: string): Promise<Snapshot>;
+  execute(id: SnapshotId): Promise<Snapshot>;
 }
 
 class ArchiveSnapshotInMemory implements ArchiveSnapshot {
   constructor(private readonly snapShots: Map<string, Snapshot>) {}
 
-  async execute(id: string): Promise<Snapshot> {
+  async execute(id: SnapshotId): Promise<Snapshot> {
     const foundSnapshot = this.snapShots.get(id);
     if (!foundSnapshot) {
       throw new SnapshotNotFoundError(id);

--- a/backend/src/domain/inventory/archiveSnapshot.ts
+++ b/backend/src/domain/inventory/archiveSnapshot.ts
@@ -1,0 +1,23 @@
+import { SnapshotNotFoundError } from "./models/errors/snapshotNotFoundError";
+import { Snapshot } from "./models/snapshots/snapshot";
+
+interface ArchiveSnapshot {
+  execute(id: string): Promise<Snapshot>;
+}
+
+class ArchiveSnapshotInMemory implements ArchiveSnapshot {
+  constructor(private readonly snapShots: Map<string, Snapshot>) {}
+
+  async execute(id: string): Promise<Snapshot> {
+    const foundSnapshot = this.snapShots.get(id);
+    if (!foundSnapshot) {
+      throw new SnapshotNotFoundError(id);
+    }
+
+    this.snapShots.set(id, { ...foundSnapshot, archived: true });
+
+    return foundSnapshot;
+  }
+}
+
+export { ArchiveSnapshot, ArchiveSnapshotInMemory };

--- a/backend/src/domain/inventory/getSnapshot.ts
+++ b/backend/src/domain/inventory/getSnapshot.ts
@@ -6,10 +6,17 @@ interface GetSnapshot {
 }
 
 class GetSnapshotFromMemory implements GetSnapshot {
-  constructor(private readonly snapShots: Map<string, Snapshot>) {}
+  constructor(private readonly snapShots: Map<string, Snapshot[]>) {}
 
   async oldestForShop(id: ShopId): Promise<Snapshot | undefined> {
-    return this.snapShots.get(id) || undefined;
+    const allSnapshots = this.snapShots.get(id);
+    if (!allSnapshots) {
+      return undefined;
+    }
+    // return oldest snapshot
+    return allSnapshots
+      .filter((s) => !s.archived)
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())[0];
   }
 }
 

--- a/backend/src/domain/inventory/getSnapshot.ts
+++ b/backend/src/domain/inventory/getSnapshot.ts
@@ -1,8 +1,10 @@
 import { ShopId } from "../shops";
-import { Snapshot } from "./models/snapshots/snapshot";
+import { SnapshotNotFoundError } from "./models/errors/snapshotNotFoundError";
+import { Snapshot, SnapshotId } from "./models/snapshots/snapshot";
 
 interface GetSnapshot {
   oldestForShop(id: ShopId): Promise<Snapshot | undefined>;
+  byId(id: SnapshotId): Promise<Snapshot>;
 }
 
 class GetSnapshotFromMemory implements GetSnapshot {
@@ -17,6 +19,13 @@ class GetSnapshotFromMemory implements GetSnapshot {
     return allSnapshots
       .filter((s) => !s.archived)
       .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())[0];
+  }
+  async byId(id: SnapshotId): Promise<Snapshot> {
+    const found = [...this.snapShots.values()].flat().find((s) => s.id === id);
+    if (!found) {
+      throw new SnapshotNotFoundError(id);
+    }
+    return found;
   }
 }
 

--- a/backend/src/domain/inventory/models/errors/snapshotNotFoundError.ts
+++ b/backend/src/domain/inventory/models/errors/snapshotNotFoundError.ts
@@ -1,0 +1,6 @@
+class SnapshotNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Snapshot with id '${id}' not found`);
+  }
+}
+export { SnapshotNotFoundError };

--- a/backend/src/domain/inventory/models/snapshots/snapshot.ts
+++ b/backend/src/domain/inventory/models/snapshots/snapshot.ts
@@ -1,10 +1,12 @@
 import { WithFlavor } from "@coderspirit/nominal";
 import { CabinetItem } from ".";
+import { ShopId } from "../../../shops";
 
 type SnapshotId = WithFlavor<string, "SnapshotId">;
 class Snapshot {
   constructor(
     public readonly id: SnapshotId,
+    public readonly shop: ShopId,
     public readonly contents: CabinetItem[],
     public readonly createdAt: Date = new Date(),
     public readonly archived: boolean = false

--- a/backend/src/domain/inventory/models/snapshots/snapshot.ts
+++ b/backend/src/domain/inventory/models/snapshots/snapshot.ts
@@ -4,7 +4,8 @@ class Snapshot {
   constructor(
     public readonly id: string,
     public readonly contents: CabinetItem[],
-    public readonly processed: boolean = false
+    public readonly createdAt: Date = new Date(),
+    public readonly archived: boolean = false
   ) {}
 }
 

--- a/backend/src/domain/inventory/models/snapshots/snapshot.ts
+++ b/backend/src/domain/inventory/models/snapshots/snapshot.ts
@@ -1,12 +1,14 @@
+import { WithFlavor } from "@coderspirit/nominal";
 import { CabinetItem } from ".";
 
+type SnapshotId = WithFlavor<string, "SnapshotId">;
 class Snapshot {
   constructor(
-    public readonly id: string,
+    public readonly id: SnapshotId,
     public readonly contents: CabinetItem[],
     public readonly createdAt: Date = new Date(),
     public readonly archived: boolean = false
   ) {}
 }
 
-export { Snapshot };
+export { Snapshot, SnapshotId };

--- a/backend/src/domain/inventory/storeSnapshot.ts
+++ b/backend/src/domain/inventory/storeSnapshot.ts
@@ -4,19 +4,18 @@ import { CabinetItem } from "./models";
 import { Snapshot } from "./models/snapshots/snapshot";
 
 interface StoreSnapshot {
-  forShop(id: ShopId, rawInventory: CabinetItem[]): Promise<void>;
+  forShop(id: ShopId, rawInventory: CabinetItem[]): Promise<Snapshot>;
 }
 
 class StoreSnapshotInMemory implements StoreSnapshot {
   constructor(private readonly storeInventories: Map<string, Snapshot[]>) {}
 
-  async forShop(id: ShopId, cabinetItems: CabinetItem[]): Promise<void> {
+  async forShop(id: ShopId, cabinetItems: CabinetItem[]): Promise<Snapshot> {
     const existingSnapshots = this.storeInventories.get(id) || [];
-    const toStore = [
-      ...existingSnapshots,
-      new Snapshot(randomUUID(), cabinetItems),
-    ];
+    const newSnapshot = new Snapshot(randomUUID(), id, cabinetItems);
+    const toStore = [...existingSnapshots, newSnapshot];
     this.storeInventories.set(id, toStore);
+    return newSnapshot;
   }
 }
 export { StoreSnapshot, StoreSnapshotInMemory };

--- a/backend/src/domain/inventory/storeSnapshot.ts
+++ b/backend/src/domain/inventory/storeSnapshot.ts
@@ -1,14 +1,22 @@
+import { randomUUID } from "crypto";
 import { ShopId } from "../shops";
 import { CabinetItem } from "./models";
+import { Snapshot } from "./models/snapshots/snapshot";
 
 interface StoreSnapshot {
   forShop(id: ShopId, rawInventory: CabinetItem[]): Promise<void>;
 }
 
 class StoreSnapshotInMemory implements StoreSnapshot {
-  constructor(private readonly storeInventories: Map<string, CabinetItem[]>) {}
-  async forShop(id: ShopId, rawInventory: CabinetItem[]): Promise<void> {
-    this.storeInventories.set(id, rawInventory);
+  constructor(private readonly storeInventories: Map<string, Snapshot[]>) {}
+
+  async forShop(id: ShopId, cabinetItems: CabinetItem[]): Promise<void> {
+    const existingSnapshots = this.storeInventories.get(id) || [];
+    const toStore = [
+      ...existingSnapshots,
+      new Snapshot(randomUUID(), cabinetItems),
+    ];
+    this.storeInventories.set(id, toStore);
   }
 }
 export { StoreSnapshot, StoreSnapshotInMemory };

--- a/backend/src/ports/postgres/inventory/archiveSnapshotInPostgres.ts
+++ b/backend/src/ports/postgres/inventory/archiveSnapshotInPostgres.ts
@@ -1,0 +1,19 @@
+import { ArchiveSnapshot } from "../../../domain/inventory/archiveSnapshot";
+import { SnapshotNotFoundError } from "../../../domain/inventory/models/errors/snapshotNotFoundError";
+import { SnapshotId } from "../../../domain/inventory/models/snapshots/snapshot";
+import { Postgres } from "../postgres";
+
+class ArchiveSnapshotInPostgres implements ArchiveSnapshot {
+  constructor(private readonly database: Postgres) {}
+  async execute(id: SnapshotId): Promise<void> {
+    const query = `UPDATE raw_inventory_data set archived = true where id = $1`;
+    const values = [id];
+    const result = await this.database.sql.query(query, values);
+
+    if (result.rowCount === 0) {
+      throw new SnapshotNotFoundError(id);
+    }
+  }
+}
+
+export { ArchiveSnapshotInPostgres };

--- a/backend/src/ports/postgres/inventory/getSnapshotFromPostgres.ts
+++ b/backend/src/ports/postgres/inventory/getSnapshotFromPostgres.ts
@@ -6,25 +6,26 @@ import { Postgres } from "../postgres";
 class GetSnapshotFromPostgres implements GetSnapshot {
   constructor(private readonly postgres: Postgres) {}
 
-  async oldestForShop(id: ShopId): Promise<Snapshot | undefined> {
+  async oldestForShop(shopId: ShopId): Promise<Snapshot | undefined> {
     const query = `SELECT raw_data FROM raw_inventory_data WHERE shop=$1 ORDER BY created_at ASC LIMIT 1`;
-    const result = await this.postgres.sql.query(query, [id]);
+    const result = await this.postgres.sql.query(query, [shopId]);
 
     if (result.rowCount === 0) {
       return undefined;
     }
 
     if (result.rowCount > 1) {
-      throw new Error(`Multiple rows for shop ${id}. Only one expected`);
+      throw new Error(`Multiple rows for shop ${shopId}. Only one expected`);
     }
     const foundRow = result.rows[0];
 
-    const snapshot = new Snapshot(
+    return new Snapshot(
       foundRow.id,
+      shopId,
       foundRow.raw_data,
-      foundRow.created_at
+      foundRow.created_at,
+      foundRow.archived
     );
-    return snapshot;
   }
 }
 

--- a/backend/src/ports/postgres/inventory/getSnapshotFromPostgres.ts
+++ b/backend/src/ports/postgres/inventory/getSnapshotFromPostgres.ts
@@ -19,8 +19,11 @@ class GetSnapshotFromPostgres implements GetSnapshot {
     }
     const foundRow = result.rows[0];
 
-    // TODO: Add migration to create processed column
-    const snapshot = new Snapshot(foundRow.id, foundRow.raw_data, false);
+    const snapshot = new Snapshot(
+      foundRow.id,
+      foundRow.raw_data,
+      foundRow.created_at
+    );
     return snapshot;
   }
 }

--- a/backend/src/ports/postgres/inventory/getSnapshotFromPostgres.ts
+++ b/backend/src/ports/postgres/inventory/getSnapshotFromPostgres.ts
@@ -1,5 +1,9 @@
 import { GetSnapshot } from "../../../domain/inventory";
-import { Snapshot } from "../../../domain/inventory/models/snapshots/snapshot";
+import { SnapshotNotFoundError } from "../../../domain/inventory/models/errors/snapshotNotFoundError";
+import {
+  Snapshot,
+  SnapshotId,
+} from "../../../domain/inventory/models/snapshots/snapshot";
 import { ShopId } from "../../../domain/shops";
 import { Postgres } from "../postgres";
 
@@ -26,6 +30,22 @@ class GetSnapshotFromPostgres implements GetSnapshot {
       foundRow.created_at,
       foundRow.archived
     );
+  }
+  async byId(id: SnapshotId): Promise<Snapshot> {
+    const query = `SELECT id, raw_data, shop, created_at, archived FROM raw_inventory_data WHERE id=$1`;
+    const result = await this.postgres.sql.query(query, [id]);
+
+    if (result.rowCount) {
+      const foundRow = result.rows[0];
+      return new Snapshot(
+        foundRow.id,
+        foundRow.shop,
+        foundRow.raw_data,
+        foundRow.created_at,
+        foundRow.archived
+      );
+    }
+    throw new SnapshotNotFoundError(id);
   }
 }
 

--- a/backend/src/ports/postgres/inventory/storeSnapshotInPostgres.ts
+++ b/backend/src/ports/postgres/inventory/storeSnapshotInPostgres.ts
@@ -1,13 +1,23 @@
 import { ShopId } from "../../../domain/shops";
 import { Postgres } from "../postgres";
 import { CabinetItem, StoreSnapshot } from "../../../domain/inventory";
+import { Snapshot } from "../../../domain/inventory/models/snapshots/snapshot";
 
 class StoreSnapshotInPostgres implements StoreSnapshot {
   constructor(private readonly postgres: Postgres) {}
-  async forShop(id: ShopId, rawInventory: CabinetItem[]): Promise<void> {
-    await this.postgres.sql.query(
-      `INSERT INTO raw_inventory_data (shop, raw_data) values ($1, $2)`,
+  async forShop(id: ShopId, rawInventory: CabinetItem[]): Promise<Snapshot> {
+    const createdRow = await this.postgres.sql.query(
+      `INSERT INTO raw_inventory_data (shop, raw_data) values ($1, $2) RETURNING id, shop, raw_data, created_at, archived`,
       [id, JSON.stringify(rawInventory)]
+    );
+
+    const created = createdRow.rows[0];
+    return new Snapshot(
+      created.id,
+      created.shop,
+      created.raw_data,
+      created.created_at,
+      created.archived
     );
   }
 }

--- a/backend/tools/backfill-production-to-dev.ts
+++ b/backend/tools/backfill-production-to-dev.ts
@@ -1,7 +1,7 @@
 import { config } from "dotenv";
 import { asNumber, asString } from "../src/lib/parsing";
 import { Postgres } from "../src/ports/postgres/postgres";
-import format, { string } from "pg-format";
+import format from "pg-format";
 (async () => {
   const start = (status: string) =>
     console.log(`-------START - ${status.toUpperCase()} -------`);
@@ -50,12 +50,6 @@ import format, { string } from "pg-format";
     `SELECT id, name from shops`
   );
 
-  type ShopMapping = {
-    name: string;
-    from: string;
-    to: string;
-  };
-
   type fromId = string;
   type toId = string;
 
@@ -65,6 +59,7 @@ import format, { string } from "pg-format";
     name: row.name,
   }));
   for (const shop of productionShops.rows) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const { id: devId } = devShops.find((s) => s.name === shop.name)!;
     mappings.set(shop.id, devId);
   }


### PR DESCRIPTION
- Fix up the massacre that is not planning up front...
- Add 'archived' to 'raw_inventory_data'
- Ensure we also update the shop ids so that we maintain referential integrity.
- Add snapshotid flavor
- Return created snapshots instead of relying on another query to go and fetch that
- Add query to get snapshot by id
- Add snapshot archiving command
