### PR TITLE
bunch of cleanup and a bit of a start on downsync worker

### DIFF
--- a/backend/__tests__/domain/inventory/downSyncInventory.unit.test.ts
+++ b/backend/__tests__/domain/inventory/downSyncInventory.unit.test.ts
@@ -4,7 +4,10 @@ import {
   TakeSnapshotsForAllShops,
 } from "../../../src/domain/inventory";
 import { CabinetItem } from "../../../src/domain/inventory/models";
-import { Snapshot } from "../../../src/domain/inventory/models/snapshots/snapshot";
+import {
+  Snapshot,
+  SnapshotId,
+} from "../../../src/domain/inventory/models/snapshots/snapshot";
 import { Shop, GetAllShopsFromMemory } from "../../../src/domain/shops";
 import { singleCabinetItem } from "../../fixtures";
 
@@ -31,7 +34,7 @@ describe("TakeInventorySnapshot", () => {
   externalShopInventories.set(firstShop.id, [firstShopInventory]);
   externalShopInventories.set(secondShop.id, [secondShopInventory]);
 
-  const storedSnapshots = new Map<string, Snapshot[]>();
+  const storedSnapshots = new Map<SnapshotId, Snapshot>();
   const getAllShops = new GetAllShopsFromMemory(shops);
   const fetchInventory = new FetchMockedSnapshotFromMemory(
     externalShopInventories
@@ -48,10 +51,7 @@ describe("TakeInventorySnapshot", () => {
 
     expect(storedSnapshots.size).toBe(2);
     expect(
-      storedSnapshots.get(firstShop.id)?.flatMap((s) => s.contents)
-    ).toEqual([firstShopInventory]);
-    expect(
-      storedSnapshots.get(secondShop.id)?.flatMap((s) => s.contents)
-    ).toEqual([secondShopInventory]);
+      [...storedSnapshots.values()].flatMap((s) => s.contents)
+    ).toContainEqual(firstShopInventory);
   });
 });

--- a/backend/__tests__/domain/inventory/downSyncInventory.unit.test.ts
+++ b/backend/__tests__/domain/inventory/downSyncInventory.unit.test.ts
@@ -1,14 +1,14 @@
 import {
-  CabinetItem,
   FetchMockedSnapshotFromMemory,
   StoreSnapshotInMemory,
   TakeSnapshotsForAllShops,
 } from "../../../src/domain/inventory";
+import { CabinetItem } from "../../../src/domain/inventory/models";
 import { Snapshot } from "../../../src/domain/inventory/models/snapshots/snapshot";
 import { Shop, GetAllShopsFromMemory } from "../../../src/domain/shops";
 import { singleCabinetItem } from "../../fixtures";
 
-describe("DownSyncInventory", () => {
+describe("TakeInventorySnapshot", () => {
   const firstShop = new Shop(
     "c9b4da19-d70b-41d1-8272-cfea007eacc4",
     "First Shop"

--- a/backend/__tests__/domain/inventory/importInventorySnapshot.unit.test.ts
+++ b/backend/__tests__/domain/inventory/importInventorySnapshot.unit.test.ts
@@ -1,0 +1,61 @@
+import {
+  CabinetItem,
+  FetchMockedSnapshotFromMemory,
+  GetSnapshotFromMemory,
+  StoreSnapshotInMemory,
+} from "../../../src/domain/inventory";
+import { CreateSimpleProductInMemory } from "../../../src/domain/inventory/createSimpleProduct";
+import { ImportInventorySnapshots } from "../../../src/domain/inventory/importInventorySnapshots";
+import { SimpleProduct } from "../../../src/domain/inventory/models/simpleProduct";
+import { Snapshot } from "../../../src/domain/inventory/models/snapshots/snapshot";
+import {
+  CreateNewShopInMemory,
+  GetAllShopsFromMemory,
+  Shop,
+} from "../../../src/domain/shops";
+import {
+  makeSingleCabinetItem,
+  singleCabinetItemAsArray,
+} from "../../fixtures";
+import { makeProductToCreateFor } from "../../fixtures/simpleProduct";
+
+describe("ImportInventorySnapshot", () => {
+  const allInventories = new Map<string, SimpleProduct[]>();
+  const snapshots = new Map<string, Snapshot>();
+  const shops: Shop[] = [];
+  const createShop = new CreateNewShopInMemory(shops);
+  const getAllShops = new GetAllShopsFromMemory(shops);
+  const createProduct = new CreateSimpleProductInMemory(allInventories);
+  const fetchSnapshotExternally = new GetSnapshotFromMemory(snapshots);
+  const storeRawInventory = new StoreSnapshotInMemory(snapshots);
+
+  const importInventorySnapshots = new ImportInventorySnapshots(
+    getAllShops,
+    fetchSnapshotExternally,
+    createProduct
+  );
+  let shopA: Shop;
+  let shopB: Shop;
+  beforeEach(async () => {
+    allInventories.clear();
+    snapshots.clear();
+    shopA = await createShop.execute({ name: "shopA" });
+    shopB = await createShop.execute({ name: "shopB" });
+  });
+
+  it("should create a new product if one does not exist", async () => {
+    await storeRawInventory.forShop(shopA, singleCabinetItemAsArray);
+    await importInventorySnapshots.run();
+    expect(allInventories.get(shopA.id)).toHaveLength(1);
+  });
+  it("should update an existing product if one exists", async () => {
+    const existingProduct = await createProduct.execute(
+      makeProductToCreateFor(shopA)
+    );
+    const snapshotItem = makeSingleCabinetItem({ epc: existingProduct.ean });
+    await storeRawInventory.forShop(shopA, [snapshotItem]);
+    await importInventorySnapshots.run();
+    expect(allInventories.get(shopA.id)).toHaveLength(1);
+  });
+  it("should mark a snapshot as processed so that subsequent runs don't process it again", async () => {});
+});

--- a/backend/__tests__/domain/inventory/importInventorySnapshot.unit.test.ts
+++ b/backend/__tests__/domain/inventory/importInventorySnapshot.unit.test.ts
@@ -1,6 +1,4 @@
 import {
-  CabinetItem,
-  FetchMockedSnapshotFromMemory,
   GetSnapshotFromMemory,
   StoreSnapshotInMemory,
 } from "../../../src/domain/inventory";
@@ -27,7 +25,7 @@ describe("ImportInventorySnapshot", () => {
   const getAllShops = new GetAllShopsFromMemory(shops);
   const createProduct = new CreateSimpleProductInMemory(allInventories);
   const fetchSnapshotExternally = new GetSnapshotFromMemory(snapshots);
-  const storeRawInventory = new StoreSnapshotInMemory(snapshots);
+  const storeSnapshot = new StoreSnapshotInMemory(snapshots);
 
   const importInventorySnapshots = new ImportInventorySnapshots(
     getAllShops,
@@ -44,7 +42,7 @@ describe("ImportInventorySnapshot", () => {
   });
 
   it("should create a new product if one does not exist", async () => {
-    await storeRawInventory.forShop(shopA, singleCabinetItemAsArray);
+    await storeSnapshot.forShop(shopA, singleCabinetItemAsArray);
     await importInventorySnapshots.run();
     expect(allInventories.get(shopA.id)).toHaveLength(1);
   });
@@ -52,10 +50,12 @@ describe("ImportInventorySnapshot", () => {
     const existingProduct = await createProduct.execute(
       makeProductToCreateFor(shopA)
     );
-    const snapshotItem = makeSingleCabinetItem({ epc: existingProduct.ean });
-    await storeRawInventory.forShop(shopA, [snapshotItem]);
+    const snapshotItem = makeSingleCabinetItem({ epc: existingProduct.epc });
+    await storeSnapshot.forShop(shopA, [snapshotItem]);
     await importInventorySnapshots.run();
     expect(allInventories.get(shopA.id)).toHaveLength(1);
   });
-  it("should mark a snapshot as processed so that subsequent runs don't process it again", async () => {});
+  it.todo(
+    "should mark a snapshot as processed so that subsequent runs don't process it again"
+  );
 });

--- a/backend/__tests__/domain/inventory/importInventorySnapshot.unit.test.ts
+++ b/backend/__tests__/domain/inventory/importInventorySnapshot.unit.test.ts
@@ -1,19 +1,19 @@
 import {
+  CreateSimpleProductInMemory,
   GetSnapshotFromMemory,
   StoreSnapshotInMemory,
+  ImportInventorySnapshots,
+  SimpleProduct,
+  Snapshot,
 } from "../../../src/domain/inventory";
-import { CreateSimpleProductInMemory } from "../../../src/domain/inventory/createSimpleProduct";
-import { ImportInventorySnapshots } from "../../../src/domain/inventory/importInventorySnapshots";
-import { SimpleProduct } from "../../../src/domain/inventory/models/simpleProduct";
-import { Snapshot } from "../../../src/domain/inventory/models/snapshots/snapshot";
 import {
+  Shop,
   CreateNewShopInMemory,
   GetAllShopsFromMemory,
-  Shop,
 } from "../../../src/domain/shops";
 import {
-  makeSingleCabinetItem,
   singleCabinetItemAsArray,
+  makeSingleCabinetItem,
 } from "../../fixtures";
 import { makeProductToCreateFor } from "../../fixtures/simpleProduct";
 

--- a/backend/__tests__/domain/inventory/importInventorySnapshot.unit.test.ts
+++ b/backend/__tests__/domain/inventory/importInventorySnapshot.unit.test.ts
@@ -1,16 +1,18 @@
 import {
-  CreateSimpleProductInMemory,
   GetSnapshotFromMemory,
   StoreSnapshotInMemory,
   ImportInventorySnapshots,
   SimpleProduct,
   Snapshot,
 } from "../../../src/domain/inventory";
+import { ArchiveSnapshotInMemory } from "../../../src/domain/inventory/archiveSnapshot";
+import { CreateSimpleProductInMemory } from "../../../src/domain/inventory/createSimpleProduct";
 import {
   Shop,
   CreateNewShopInMemory,
   GetAllShopsFromMemory,
 } from "../../../src/domain/shops";
+import { ArchiveSnapshotInPostgres } from "../../../src/ports/postgres/inventory/archiveSnapshotInPostgres";
 import {
   singleCabinetItemAsArray,
   makeSingleCabinetItem,
@@ -20,43 +22,52 @@ import { makeProductToCreateFor } from "../../fixtures/simpleProduct";
 describe("ImportInventorySnapshot", () => {
   const allInventories = new Map<string, SimpleProduct[]>();
   const snapshots = new Map<string, Snapshot[]>();
-  const shops: Shop[] = [];
+  let shops: Shop[] = [];
   const createShop = new CreateNewShopInMemory(shops);
   const getAllShops = new GetAllShopsFromMemory(shops);
   const createProduct = new CreateSimpleProductInMemory(allInventories);
   const getSnapshot = new GetSnapshotFromMemory(snapshots);
   const storeSnapshot = new StoreSnapshotInMemory(snapshots);
-
+  const markSnapshotAsProcessed = new ArchiveSnapshotInMemory(snapshots);
   const importInventorySnapshots = new ImportInventorySnapshots(
     getAllShops,
     getSnapshot,
-    createProduct
+    createProduct,
+    markSnapshotAsProcessed
   );
   let shopA: Shop;
   let shopB: Shop;
   beforeEach(async () => {
     allInventories.clear();
     snapshots.clear();
+    shops = [];
     shopA = await createShop.execute({ name: "shopA" });
     shopB = await createShop.execute({ name: "shopB" });
   });
 
   it("should create a new product if one does not exist", async () => {
-    await storeSnapshot.forShop(shopA, singleCabinetItemAsArray);
+    await storeSnapshot.forShop(shopA.id, singleCabinetItemAsArray);
     await importInventorySnapshots.run();
     expect(allInventories.get(shopA.id)).toHaveLength(1);
   });
   it("should update an existing product if one exists", async () => {
     const existingProduct = await createProduct.execute(
-      makeProductToCreateFor(shopA)
+      makeProductToCreateFor(shopA.id)
     );
     const snapshotItem = makeSingleCabinetItem({ epc: existingProduct.epc });
-    await storeSnapshot.forShop(shopA, [snapshotItem]);
+    await storeSnapshot.forShop(shopA.id, [snapshotItem]);
     await importInventorySnapshots.run();
 
     expect(allInventories.get(shopA.id)).toHaveLength(1);
   });
+  it("should mark a snapshot as processed so that subsequent runs don't process it again", async () => {
+    await storeSnapshot.forShop(shopA.id, singleCabinetItemAsArray);
+    await importInventorySnapshots.run();
+
+    const relevantSnapshot = snapshots.get(shopA.id)?.[0];
+    expect(relevantSnapshot?.archived).toBeTruthy();
+  });
   it.todo(
-    "should mark a snapshot as processed so that subsequent runs don't process it again"
+    "should mark a snapshot as processed so that subsequent runs don't process it again 2"
   );
 });

--- a/backend/__tests__/domain/inventory/importInventorySnapshot.unit.test.ts
+++ b/backend/__tests__/domain/inventory/importInventorySnapshot.unit.test.ts
@@ -19,7 +19,7 @@ import { makeProductToCreateFor } from "../../fixtures/simpleProduct";
 
 describe("ImportInventorySnapshot", () => {
   const allInventories = new Map<string, SimpleProduct[]>();
-  const snapshots = new Map<string, Snapshot>();
+  const snapshots = new Map<string, Snapshot[]>();
   const shops: Shop[] = [];
   const createShop = new CreateNewShopInMemory(shops);
   const getAllShops = new GetAllShopsFromMemory(shops);

--- a/backend/__tests__/domain/inventory/importInventorySnapshot.unit.test.ts
+++ b/backend/__tests__/domain/inventory/importInventorySnapshot.unit.test.ts
@@ -24,12 +24,12 @@ describe("ImportInventorySnapshot", () => {
   const createShop = new CreateNewShopInMemory(shops);
   const getAllShops = new GetAllShopsFromMemory(shops);
   const createProduct = new CreateSimpleProductInMemory(allInventories);
-  const fetchSnapshotExternally = new GetSnapshotFromMemory(snapshots);
+  const getSnapshot = new GetSnapshotFromMemory(snapshots);
   const storeSnapshot = new StoreSnapshotInMemory(snapshots);
 
   const importInventorySnapshots = new ImportInventorySnapshots(
     getAllShops,
-    fetchSnapshotExternally,
+    getSnapshot,
     createProduct
   );
   let shopA: Shop;
@@ -53,6 +53,7 @@ describe("ImportInventorySnapshot", () => {
     const snapshotItem = makeSingleCabinetItem({ epc: existingProduct.epc });
     await storeSnapshot.forShop(shopA, [snapshotItem]);
     await importInventorySnapshots.run();
+
     expect(allInventories.get(shopA.id)).toHaveLength(1);
   });
   it.todo(

--- a/backend/__tests__/domain/inventory/importInventorySnapshot.unit.test.ts
+++ b/backend/__tests__/domain/inventory/importInventorySnapshot.unit.test.ts
@@ -36,13 +36,12 @@ describe("ImportInventorySnapshot", () => {
     markSnapshotAsProcessed
   );
   let shopA: Shop;
-  let shopB: Shop;
   beforeEach(async () => {
     allInventories.clear();
     snapshots.clear();
     shops = [];
     shopA = await createShop.execute({ name: "shopA" });
-    shopB = await createShop.execute({ name: "shopB" });
+    await createShop.execute({ name: "shopB" });
   });
 
   it("should create a new product if one does not exist", async () => {
@@ -70,7 +69,4 @@ describe("ImportInventorySnapshot", () => {
     const relevantSnapshot = snapshots.get(existingSnapshot.id);
     expect(relevantSnapshot?.archived).toBeTruthy();
   });
-  it.todo(
-    "should mark a snapshot as processed so that subsequent runs don't process it again 2"
-  );
 });

--- a/backend/__tests__/fixtures/simpleProduct.ts
+++ b/backend/__tests__/fixtures/simpleProduct.ts
@@ -7,7 +7,7 @@ export const makeProductToCreateFor = (
 ): ProductToCreate => {
   const template = {
     cabinet: "Cabinet 1",
-    ean: "12345678901",
+    epc: "12345678901",
     name: "Product 1",
     quantity: 10,
     shopId: forShop.id,

--- a/backend/__tests__/fixtures/simpleProduct.ts
+++ b/backend/__tests__/fixtures/simpleProduct.ts
@@ -1,0 +1,16 @@
+import { ProductToCreate } from "../../src/domain/inventory/createSimpleProduct";
+import { ShopId } from "../../src/domain/shops";
+
+export const makeProductToCreateFor = (
+  forShop: ShopId,
+  patch?: Partial<ProductToCreate>
+): ProductToCreate => {
+  const template = {
+    cabinet: "Cabinet 1",
+    ean: "12345678901",
+    name: "Product 1",
+    quantity: 10,
+    shopId: forShop.id,
+  };
+  return { ...template, ...patch };
+};

--- a/backend/__tests__/fixtures/simpleProduct.ts
+++ b/backend/__tests__/fixtures/simpleProduct.ts
@@ -10,7 +10,7 @@ export const makeProductToCreateFor = (
     epc: "12345678901",
     name: "Product 1",
     quantity: 10,
-    shopId: forShop.id,
+    shopId: forShop,
   };
   return { ...template, ...patch };
 };

--- a/backend/__tests__/fixtures/singleCabinetItem.ts
+++ b/backend/__tests__/fixtures/singleCabinetItem.ts
@@ -1,4 +1,6 @@
-export const singleCabinetItem = {
+import { CabinetItem } from "../../src/domain/inventory";
+
+export const singleCabinetItem: CabinetItem = {
   amount: 24,
   antenna: 1,
   barcode: "0000000000000",
@@ -11,3 +13,8 @@ export const singleCabinetItem = {
   },
   quality: "good",
 };
+
+export const makeSingleCabinetItem = (patch?: Partial<CabinetItem>) => ({
+  ...singleCabinetItem,
+  ...patch,
+});

--- a/backend/__tests__/fixtures/singleCabinetItem.ts
+++ b/backend/__tests__/fixtures/singleCabinetItem.ts
@@ -1,4 +1,4 @@
-import { CabinetItem } from "../../src/domain/inventory";
+import { CabinetItem } from "../../src/domain/inventory/models";
 
 export const singleCabinetItem: CabinetItem = {
   amount: 24,

--- a/backend/__tests__/ports/postgres/inventory/getSnapshotFromPostgres.int.test.ts
+++ b/backend/__tests__/ports/postgres/inventory/getSnapshotFromPostgres.int.test.ts
@@ -1,4 +1,4 @@
-import { CabinetItem } from "../../../../src/domain/inventory";
+import { CabinetItem } from "../../../../src/domain/inventory/models";
 
 import { CreateNewShopInPostgres } from "../../../../src/ports/postgres/shops";
 import { singleCabinetItem } from "../../../fixtures";

--- a/backend/__tests__/ports/postgres/inventory/storeSnapshotInPostgres.int.test.ts
+++ b/backend/__tests__/ports/postgres/inventory/storeSnapshotInPostgres.int.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto";
-import { CabinetItem } from "../../../../src/domain/inventory";
+import { CabinetItem } from "../../../../src/domain/inventory/models";
+
 import {
   GetSnapshotFromPostgres,
   StoreSnapshotInPostgres,

--- a/backend/src/domain/inventory/archiveSnapshot.ts
+++ b/backend/src/domain/inventory/archiveSnapshot.ts
@@ -6,7 +6,7 @@ interface ArchiveSnapshot {
 }
 
 class ArchiveSnapshotInMemory implements ArchiveSnapshot {
-  constructor(private readonly snapShots: Map<string, Snapshot>) {}
+  constructor(private readonly snapShots: Map<SnapshotId, Snapshot>) {}
 
   async execute(id: SnapshotId): Promise<void> {
     const foundSnapshot = this.snapShots.get(id);

--- a/backend/src/domain/inventory/createSimpleProduct.ts
+++ b/backend/src/domain/inventory/createSimpleProduct.ts
@@ -34,7 +34,7 @@ class CreateSimpleProductInMemory implements CreateSimpleProduct {
     // All of this is dirty as heck, and needs to be replicated in the postgres
     //  implementation as well. So yeah, not "great"
     const indexOfExistingProduct = inventory.findIndex(
-      (product) => product.ean === ean
+      (product) => product.epc === epc
     );
     if (indexOfExistingProduct >= 0) {
       inventory[indexOfExistingProduct] = toCreate;

--- a/backend/src/domain/inventory/createSimpleProduct.ts
+++ b/backend/src/domain/inventory/createSimpleProduct.ts
@@ -29,7 +29,19 @@ class CreateSimpleProductInMemory implements CreateSimpleProduct {
       cabinet,
       shopId
     );
-    this.allShopInventories.get(shopId)?.push(toCreate);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const inventory = this.allShopInventories.get(shopId)!;
+    // All of this is dirty as heck, and needs to be replicated in the postgres
+    //  implementation as well. So yeah, not "great"
+    const indexOfExistingProduct = inventory.findIndex(
+      (product) => product.ean === ean
+    );
+    if (indexOfExistingProduct >= 0) {
+      inventory[indexOfExistingProduct] = toCreate;
+    } else {
+      inventory.push(toCreate);
+    }
+
     return toCreate;
   }
 }

--- a/backend/src/domain/inventory/fromCabinetItemToSimpleProduct.ts
+++ b/backend/src/domain/inventory/fromCabinetItemToSimpleProduct.ts
@@ -13,7 +13,7 @@ export const fromCabinetItemToSimpleProduct =
     return {
       name: name,
       cabinet: location,
-      ean: epc, //TODO: Fix this
+      epc,
       quantity: amount,
       shopId,
     };

--- a/backend/src/domain/inventory/fromCabinetItemToSimpleProduct.ts
+++ b/backend/src/domain/inventory/fromCabinetItemToSimpleProduct.ts
@@ -3,7 +3,7 @@ import { ProductToCreate } from "./createSimpleProduct";
 import { CabinetItem } from "./models";
 
 export const fromCabinetItemToSimpleProduct =
-  ({ id: shopId }: ShopId) =>
+  (shopId: ShopId) =>
   ({
     amount,
     epc,

--- a/backend/src/domain/inventory/fromCabinetItemToSimpleProduct.ts
+++ b/backend/src/domain/inventory/fromCabinetItemToSimpleProduct.ts
@@ -1,0 +1,20 @@
+import { ShopId } from "../shops";
+import { ProductToCreate } from "./createSimpleProduct";
+import { CabinetItem } from "./models";
+
+export const fromCabinetItemToSimpleProduct =
+  ({ id: shopId }: ShopId) =>
+  ({
+    amount,
+    epc,
+    location,
+    product: { name },
+  }: CabinetItem): ProductToCreate => {
+    return {
+      name: name,
+      cabinet: location,
+      ean: epc, //TODO: Fix this
+      quantity: amount,
+      shopId,
+    };
+  };

--- a/backend/src/domain/inventory/getSnapshot.ts
+++ b/backend/src/domain/inventory/getSnapshot.ts
@@ -6,7 +6,6 @@ interface GetSnapshot {
   oldestForShop(id: ShopId): Promise<Snapshot | undefined>;
   byId(id: SnapshotId): Promise<Snapshot>;
 }
-
 class GetSnapshotFromMemory implements GetSnapshot {
   constructor(private readonly snapShots: Map<string, Snapshot[]>) {}
 

--- a/backend/src/domain/inventory/getSnapshot.ts
+++ b/backend/src/domain/inventory/getSnapshot.ts
@@ -7,16 +7,12 @@ interface GetSnapshot {
   byId(id: SnapshotId): Promise<Snapshot>;
 }
 class GetSnapshotFromMemory implements GetSnapshot {
-  constructor(private readonly snapShots: Map<string, Snapshot[]>) {}
+  constructor(private readonly snapShots: Map<SnapshotId, Snapshot>) {}
 
-  async oldestForShop(id: ShopId): Promise<Snapshot | undefined> {
-    const allSnapshots = this.snapShots.get(id);
-    if (!allSnapshots) {
-      return undefined;
-    }
-    // return oldest snapshot
+  async oldestForShop(shopId: ShopId): Promise<Snapshot | undefined> {
+    const allSnapshots = [...this.snapShots.values()];
     return allSnapshots
-      .filter((s) => !s.archived)
+      .filter((s) => !s.archived && s.shop === shopId)
       .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())[0];
   }
   async byId(id: SnapshotId): Promise<Snapshot> {

--- a/backend/src/domain/inventory/importInventorySnapshots.ts
+++ b/backend/src/domain/inventory/importInventorySnapshots.ts
@@ -1,0 +1,30 @@
+import { GetSnapshot } from ".";
+import { GetAllShops } from "../shops";
+import { CreateSimpleProduct } from "./createSimpleProduct";
+import { fromCabinetItemToSimpleProduct } from "./fromCabinetItemToSimpleProduct";
+
+class ImportInventorySnapshots {
+  constructor(
+    private readonly getAllShops: GetAllShops,
+    private readonly getSnapshot: GetSnapshot,
+    private readonly createProduct: CreateSimpleProduct
+  ) {}
+  async run(): Promise<void> {
+    const allShops = await this.getAllShops.execute();
+    for (const shop of allShops) {
+      console.log(`Importing inventory snapshots for shop ${shop.name}`);
+      const snapshot = await this.getSnapshot.oldestForShop(shop);
+      if (!snapshot) {
+        continue;
+      }
+      const productsToCreate = snapshot.contents.map(
+        fromCabinetItemToSimpleProduct(shop)
+      );
+      console.log(`Creating ${productsToCreate.length} products`);
+      for (const product of productsToCreate) {
+        await this.createProduct.execute(product);
+      }
+    }
+  }
+}
+export { ImportInventorySnapshots };

--- a/backend/src/domain/inventory/importInventorySnapshots.ts
+++ b/backend/src/domain/inventory/importInventorySnapshots.ts
@@ -1,5 +1,6 @@
 import { GetSnapshot } from ".";
 import { GetAllShops } from "../shops";
+import { ArchiveSnapshot } from "./archiveSnapshot";
 import { CreateSimpleProduct } from "./createSimpleProduct";
 import { fromCabinetItemToSimpleProduct } from "./fromCabinetItemToSimpleProduct";
 
@@ -7,23 +8,23 @@ class ImportInventorySnapshots {
   constructor(
     private readonly getAllShops: GetAllShops,
     private readonly getSnapshot: GetSnapshot,
-    private readonly createProduct: CreateSimpleProduct
+    private readonly createProduct: CreateSimpleProduct,
+    private readonly archiveSnapshot: ArchiveSnapshot
   ) {}
   async run(): Promise<void> {
     const allShops = await this.getAllShops.execute();
-    for (const shop of allShops) {
-      console.log(`Importing inventory snapshots for shop ${shop.name}`);
-      const snapshot = await this.getSnapshot.oldestForShop(shop);
+    for (const { id: shopId } of allShops) {
+      const snapshot = await this.getSnapshot.oldestForShop(shopId);
       if (!snapshot) {
         continue;
       }
       const productsToCreate = snapshot.contents.map(
-        fromCabinetItemToSimpleProduct(shop)
+        fromCabinetItemToSimpleProduct(shopId)
       );
-      console.log(`Creating ${productsToCreate.length} products`);
       for (const product of productsToCreate) {
         await this.createProduct.execute(product);
       }
+      await this.archiveSnapshot.execute(snapshot.id);
     }
   }
 }

--- a/backend/src/domain/inventory/index.ts
+++ b/backend/src/domain/inventory/index.ts
@@ -2,4 +2,8 @@ export * from "./models";
 export * from "./takeSnapshotsForAllShops";
 export * from "./getSnapshot";
 export * from "./fetchSnapshotFromExternalSource";
+export * from "./fromCabinetItemToSimpleProduct";
+export * from "./getSimpleProduct";
+export * from "./getSnapshot";
+export * from "./importInventorySnapshots";
 export * from "./storeSnapshot";

--- a/backend/src/domain/inventory/markSnapshotAsProcessed.ts
+++ b/backend/src/domain/inventory/markSnapshotAsProcessed.ts
@@ -1,0 +1,5 @@
+interface MarkSnapshotAsProcessed {
+  execute(snapshotId: string): Promise<void>;
+}
+
+export { MarkSnapshotAsProcessed };

--- a/backend/src/domain/inventory/markSnapshotAsProcessed.ts
+++ b/backend/src/domain/inventory/markSnapshotAsProcessed.ts
@@ -1,5 +1,0 @@
-interface MarkSnapshotAsProcessed {
-  execute(snapshotId: string): Promise<void>;
-}
-
-export { MarkSnapshotAsProcessed };

--- a/backend/src/domain/inventory/models/errors/index.ts
+++ b/backend/src/domain/inventory/models/errors/index.ts
@@ -1,0 +1,1 @@
+export * from './duplicateProductInShopError';

--- a/backend/src/domain/inventory/models/index.ts
+++ b/backend/src/domain/inventory/models/index.ts
@@ -1,1 +1,3 @@
-export * from "./snapshots";
+export * from './errors';
+export * from './snapshots';
+export * from './simpleProduct';

--- a/backend/src/domain/inventory/models/snapshots/cabinetItem.ts
+++ b/backend/src/domain/inventory/models/snapshots/cabinetItem.ts
@@ -1,6 +1,8 @@
 import { Product } from "./product";
 
 export interface CabinetItem {
+  antenna: number;
+  quality: string;
   amount: number; // How many items are currently held in this location
   barcode: string; // Internal Barcode
   epc: string; // Unique global identifier for this particular product

--- a/backend/src/domain/inventory/models/snapshots/index.ts
+++ b/backend/src/domain/inventory/models/snapshots/index.ts
@@ -1,2 +1,3 @@
-export * from './cabinetItem';
-export * from './product';
+export * from "./cabinetItem";
+export * from "./product";
+export * from "./snapshot";

--- a/backend/src/domain/inventory/storeSnapshot.ts
+++ b/backend/src/domain/inventory/storeSnapshot.ts
@@ -1,20 +1,18 @@
 import { randomUUID } from "crypto";
 import { ShopId } from "../shops";
 import { CabinetItem } from "./models";
-import { Snapshot } from "./models/snapshots/snapshot";
+import { Snapshot, SnapshotId } from "./models/snapshots/snapshot";
 
 interface StoreSnapshot {
   forShop(id: ShopId, rawInventory: CabinetItem[]): Promise<Snapshot>;
 }
 
 class StoreSnapshotInMemory implements StoreSnapshot {
-  constructor(private readonly storeInventories: Map<string, Snapshot[]>) {}
+  constructor(private readonly snapshots: Map<SnapshotId, Snapshot>) {}
 
   async forShop(id: ShopId, cabinetItems: CabinetItem[]): Promise<Snapshot> {
-    const existingSnapshots = this.storeInventories.get(id) || [];
     const newSnapshot = new Snapshot(randomUUID(), id, cabinetItems);
-    const toStore = [...existingSnapshots, newSnapshot];
-    this.storeInventories.set(id, toStore);
+    this.snapshots.set(newSnapshot.id, newSnapshot);
     return newSnapshot;
   }
 }

--- a/backend/src/ports/postgres/inventory/storeSnapshotInPostgres.ts
+++ b/backend/src/ports/postgres/inventory/storeSnapshotInPostgres.ts
@@ -1,7 +1,8 @@
+import { StoreSnapshot } from "../../../domain/inventory";
+import { CabinetItem } from "../../../domain/inventory/models";
+import { Snapshot } from "../../../domain/inventory/models/snapshots/snapshot";
 import { ShopId } from "../../../domain/shops";
 import { Postgres } from "../postgres";
-import { CabinetItem, StoreSnapshot } from "../../../domain/inventory";
-import { Snapshot } from "../../../domain/inventory/models/snapshots/snapshot";
 
 class StoreSnapshotInPostgres implements StoreSnapshot {
   constructor(private readonly postgres: Postgres) {}


### PR DESCRIPTION
- Add some basic tests and scaffolding in place to project cabinet items to simple product
- Some post-snapshot-migration cleanup
- Rename downsyncinventory class to takeInventorySnapshots
- Barrel up inventory
- Add basic interface for marking snapshot as processed
- Add created timestamp to snapshot, use array of snapshots in mocks
- Clarify variable name
- Add test and basic implementation to ensure that we're marking snapshots as processed once everything has been imported
- Tighten up and simplify the snapshot in memory tests
