### PR TITLE
overwrite simple products for a shop

### DIFF
--- a/backend/src/apps/workers/import-snapshots-worker/composition-root.ts
+++ b/backend/src/apps/workers/import-snapshots-worker/composition-root.ts
@@ -7,6 +7,7 @@ import { Postgres } from "../../../ports/postgres/postgres";
 import { ImportInventorySnapshots } from "../../../domain/inventory";
 import { ArchiveSnapshotInPostgres } from "../../../ports/postgres/inventory/archiveSnapshotInPostgres";
 import { GetAllShopsFromPostgres } from "../../../ports/postgres/shops";
+import { RemoveAllSimpleProductsFromPostgres } from "../../../ports/postgres/inventory/removeAllSimpleProductsFromPostgres";
 
 interface ImportSnapshotWorkerConfiguration {
   database: Postgres;
@@ -19,13 +20,15 @@ const makeImportSnapshotWorker = ({
   const getAllShops = new GetAllShopsFromPostgres(database);
 
   const getSnapshot = new GetSnapshotFromPostgres(database);
+  const removeAllProducts = new RemoveAllSimpleProductsFromPostgres(database);
   const createProduct = new CreateSimpleProductInPostgres(database);
   const archiveSnapshot = new ArchiveSnapshotInPostgres(database);
   const importSnapshots = new ImportInventorySnapshots(
     getAllShops,
     getSnapshot,
     createProduct,
-    archiveSnapshot
+    archiveSnapshot,
+    removeAllProducts
   );
 
   return new ScheduledJob(database, "import-snapshots-worker", schedule, () =>

--- a/backend/src/domain/inventory/importInventorySnapshots.ts
+++ b/backend/src/domain/inventory/importInventorySnapshots.ts
@@ -1,4 +1,4 @@
-import { GetSnapshot, Snapshot } from ".";
+import { GetSnapshot, RemoveAllSimpleProducts, Snapshot } from ".";
 import { GetAllShops } from "../shops";
 import { ArchiveSnapshot } from "./archiveSnapshot";
 import { CreateSimpleProduct } from "./createSimpleProduct";
@@ -9,7 +9,8 @@ class ImportInventorySnapshots {
     private readonly getAllShops: GetAllShops,
     private readonly getSnapshot: GetSnapshot,
     private readonly createProduct: CreateSimpleProduct,
-    private readonly archiveSnapshot: ArchiveSnapshot
+    private readonly archiveSnapshot: ArchiveSnapshot,
+    private readonly removeSimpleProducts: RemoveAllSimpleProducts
   ) {}
   async run(): Promise<void> {
     const allShops = await this.getAllShops.execute();
@@ -22,6 +23,7 @@ class ImportInventorySnapshots {
         continue;
       }
       do {
+        await this.removeSimpleProducts.forAGivenShop(shopId);
         console.log(
           `Importing snapshot ${currentSnapshot.id} for shop ${shopId}`
         );

--- a/backend/src/ports/postgres/inventory/createSimpleProductInPostgres.ts
+++ b/backend/src/ports/postgres/inventory/createSimpleProductInPostgres.ts
@@ -8,10 +8,13 @@ import { Postgres } from "../postgres";
 
 class CreateSimpleProductInPostgres implements CreateSimpleProduct {
   constructor(private readonly postgres: Postgres) {}
-  async execute(
-    { name, quantity, shopId, epc, cabinet }: ProductToCreate,
-    overwrite = false
-  ): Promise<SimpleProduct> {
+  async execute({
+    name,
+    quantity,
+    shopId,
+    epc,
+    cabinet,
+  }: ProductToCreate): Promise<SimpleProduct> {
     const query = `
       INSERT INTO simple_products (
         epc,
@@ -39,30 +42,7 @@ class CreateSimpleProductInPostgres implements CreateSimpleProduct {
         error instanceof Error &&
         error.message.includes("simple_products_ean_shop_id_key")
       ) {
-        if (!overwrite) {
-          throw new DuplicateProductInShopError(epc, shopId);
-        }
-
-        const updated = await this.postgres.sql.query(
-          `
-          UPDATE simple_products
-          SET
-            quantity = $1,
-            name = $2,
-            cabinet = $3
-          WHERE epc = $4 AND shop_id = $5
-          returning *
-        `,
-          [quantity, name, cabinet, epc, shopId]
-        );
-        return new SimpleProduct(
-          updated.rows[0].id,
-          updated.rows[0].epc,
-          updated.rows[0].name,
-          updated.rows[0].quantity,
-          updated.rows[0].cabinet,
-          updated.rows[0].shop_id
-        );
+        throw new DuplicateProductInShopError(epc, shopId);
       }
       throw error;
     }


### PR DESCRIPTION
- Introduce deletion for all simple products for a given shop - memory storage only for now
- Added shell and initial test for removing shop-related products
- Add a few helper methods and implement this super simple query yay
- Always nuke a shops current state inventory when a new one is being imported
